### PR TITLE
Move Ack keybindings into keybindings.vim.

### DIFF
--- a/init/ack.vim
+++ b/init/ack.vim
@@ -11,8 +11,3 @@ function! AckVisual()
   cexpr system(command)
   cw
 endfunction
-
-" AckGrep current word
-map <leader>a :call AckGrep()<CR>
-" AckVisual current selection
-vmap <leader>a :call AckVisual()<CR>

--- a/init/keybindings.vim
+++ b/init/keybindings.vim
@@ -96,3 +96,8 @@ imap <F1>           <Nop>
 
 " Easy access to the shell
 map <Leader><Leader> :!
+
+" AckGrep current word
+map <leader>a :call AckGrep()<CR>
+" AckVisual current selection
+vmap <leader>a :call AckVisual()<CR>


### PR DESCRIPTION
They were mapping <leader> before <leader> was set to comma.  They
really should be here anyhow.

This fixes the NERDTree-opening problem Ben was having.
