### PR TITLE
Automatically delete old Fugitive buffers.

### DIFF
--- a/init/fugitive.vim
+++ b/init/fugitive.vim
@@ -1,0 +1,7 @@
+" Automatically delete Fugitive buffers that are no longer being used.
+" Otherwise, they tend to fill up the buffer list.
+"
+" Credit to Drew Neil of Vimcasts:
+" http://vimcasts.org/episodes/fugitive-vim-browsing-the-git-object-database/
+
+autocmd BufReadPost fugitive://* set bufhidden=delete


### PR DESCRIPTION
Otherwise, they tend to fill up the buffer list.

Credit to Drew Neil of Vimcasts:
http://vimcasts.org/episodes/fugitive-vim-browsing-the-git-object-database/
