### PR TITLE
Use a public address for vim-rails submodule.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -8,7 +8,7 @@
 	ignore = dirty
 [submodule "bundle/vim-rails"]
 	path = bundle/vim-rails
-	url = git@github.com:Casecommons/vim-rails.git
+	url = git://github.com/Casecommons/vim-rails.git
 	ignore = dirty
 [submodule "bundle/vim-cucumber"]
 	path = bundle/vim-cucumber


### PR DESCRIPTION
Using a private address (git@github.com:CaseCommons) prevents people who
aren't collaborators on the CaseCommons github account from running git
submodule update'

FWIW, the easiest way to get this into your local checkout (if you care) is to kill and re-checkout vim-config. I think otherwise git caches it deep inside the .git dir where it's much harder to change.
