### PR TITLE
Bundle when refreshing tags

### DIFF
--- a/init/keybindings.vim
+++ b/init/keybindings.vim
@@ -72,8 +72,8 @@ map <D-N>       :CommandTFlush<CR>:CommandT<CR>
 map <leader>f   :CommandTFlush<CR>:CommandT<CR>
 
 " ctags with rails load path
-map <leader>t :!rails runner 'puts $LOAD_PATH.join(" ")' \| xargs /usr/local/bin/ctags -R public/javascripts<CR>
-map <leader>T :!rails runner 'puts $LOAD_PATH.join(" ")' \| xargs rdoc -f tags<CR>
+map <leader>t :!bundle exec rails runner 'puts $LOAD_PATH.join(" ")' \| xargs /usr/local/bin/ctags -R public/javascripts<CR>
+map <leader>T :!bundle exec rails runner 'puts $LOAD_PATH.join(" ")' \| xargs rdoc -f tags<CR>
 
 " Git blame
 map <leader>g   :Gblame<CR>


### PR DESCRIPTION
Adds bundle exec for tags so tags refresh. 

It'd be nice if there was some clever way to prevent it from trying to search public/javascripts when that directory doesn't exist (as this causes ctags to fail). My bash-fu was not strong enough. 
