### PR TITLE
increase the max file size that CommandT handles

### DIFF
--- a/init/command_t.vim
+++ b/init/command_t.vim
@@ -1,2 +1,3 @@
 " Small default height for CommandT
 let g:CommandTMaxHeight=20
+let g:CommandTMaxFiles=20000


### PR DESCRIPTION
Casebook Uno has 19k+ files. Casebook Deux is approaching 7k. 

CommandT's default file limit is 10k.

Let's bump it up.
