### PR TITLE
We discussed turning off the blinking cursor

### DIFF
--- a/init/options.vim
+++ b/init/options.vim
@@ -2,6 +2,8 @@ set guifont=Inconsolata:h24
 set guioptions-=T               " Remove GUI toolbar
 set guioptions-=e               " Use text tab bar, not GUI
 set guioptions-=rL              " Remove scrollbars
+set guicursor=a:blinkon0        " Turn off the blinking cursor
+
 set notimeout                   " No command timeout
 set showcmd                     " Show typed command prefixes while waiting for operator
 set mouse=a                     " Use mouse support in XTerm/iTerm.

--- a/init/vim.vim
+++ b/init/vim.vim
@@ -1,3 +1,0 @@
-" Generic Vim configuration options
-
-set guicursor=a:blinkon0     " Turn off the blinking cursor because it redraws the entire buffer (slow)


### PR DESCRIPTION
... which is slow when using screen sharing since it forces the entire buffer to be redrawn and sent to the remote person.
