### PR TITLE
had problems cloning the vim config this week due to command-t's git repo

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -44,7 +44,7 @@
 	ignore = dirty
 [submodule "bundle/command-t"]
 	path = bundle/command-t
-	url = git://git.wincent.com/command-t.git
+	url = git://github.com/wincent/Command-T.git
 	ignore = dirty
 [submodule "bundle/vim-abolish"]
 	path = bundle/vim-abolish


### PR DESCRIPTION
turns out wincent maintains a mirror on github, which is probably more reliable - i've changed the submodule address and all seems right with the world.
