### PR TITLE
Fixed README installation instructions to have correct github repo url

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 (Re)move ~/.vim and ~/.vimrc if you have them already, and run:
 
-    git clone git@github.com:pivotal/vim-config.git ~/.vim
+    git clone git@github.com:Casecommons/vim-config.git ~/.vim
     cd ~/.vim
     git submodule update --init
     ln -s ~/.vim/vimrc ~/.vimrc


### PR DESCRIPTION
Old README for the Casecommons repo had `git clone git@github.com:pivotal/vim-config.git ~/.vim`. It should be `git clone git@github.com:Casecommons/vim-config.git ~/.vim`
