### PR TITLE
Add W as alias for w, set <f2> to toggle paste mode

### DIFF
--- a/init/keybindings.vim
+++ b/init/keybindings.vim
@@ -7,6 +7,9 @@ let maplocalleader = ";"
 " have W write as well for shift being held too long
 command W w
 
+"set pastetoggle keybinding
+set pastetoggle=<F2>
+
 " Make Y consistent with D and C
 map Y           y$
 


### PR DESCRIPTION
W should save as well as w
In insert mode, <F2> will toggle paste mode so when you paste from outside vim it won't autoindent/close.
