### PR TITLE
substitute on whole line by default

### DIFF
--- a/init/options.vim
+++ b/init/options.vim
@@ -21,6 +21,7 @@ set wildignore+=tmp/**             " ...Also tmp files.
 set wildignore+=public/uploads/**  " ...Also uploads.
 set wildignore+=public/images/**   " ...Also images.
 set wildignore+=vendor/**          " ...Also vendor.
+set gdefault                    " substitute all occurrences on a line by default
 
 set list                        " Show whitespace
 if has("gui_running")


### PR DESCRIPTION
I rarely find myself needing to substitute only the first occurrence of a string on a line. With this option, the default is to substitute all occurrences (no need for /g). If /g is used for :substitute, it substitutes the first occurrence only.
