### PR TITLE
Remove extra F12 keybinding since it's used for RunTest

### DIFF
--- a/init/terminal.vim
+++ b/init/terminal.vim
@@ -1,8 +1,4 @@
 if !has("gui_running")
-  " Map Cmd-S to <F12> in iTerm2 for Save.
-  map <F12> :w<CR>
-  map! <F12> <C-o>:w<CR>
-
   " Makes Command-T work again with arrow keys.  Not clear why.
   map <Esc>[A <Up>
 end


### PR DESCRIPTION
Remove terminal.vim F12 keybinding since it's used for RunTest and is overwriting the RunTest version.
