### PR TITLE
new split screen mappings

### DIFF
--- a/config/mappings.vim
+++ b/config/mappings.vim
@@ -23,14 +23,23 @@ vmap <leader>s  :s/
 
 vmap <leader>so :sort<CR>
 
-" Split screen
+" Split screen vertically
 map <leader>v   :vsp<CR>
+map <leader>sv  :vsp<CR>
+
+" Split screen horizontally
+map <leader>sh  :sp<CR>
 
 " Move between screens
-map <leader>=   ^W=
-map <leader>j   ^Wj
-map <leader>k   ^Wk
-map <leader>w   ^Ww
+
+" rotate through every split (vertical and horizontal)
+map <leader>sr  <C-W>w
+
+" use <leader> + AWSD instead of <leader> + HJKL
+map <leader>sa  <C-W>h
+map <leader>sw  <C-W>k
+map <leader>ss  <C-W>j
+map <leader>sd  <C-W>l
 
 " Open .vimrc file in new tab. Think Command + , [Preferences...] but with Shift.
 map <D-<>       :tabedit ~/.vimrc<CR>


### PR DESCRIPTION
I added a map for splitting the screen horizontally, and and a
similar map for splitting the screen vertically. The move between
screens mappings were not working because of `^W` instead of `<C-W>`.

I also added a map for moving up down left right with splits using
AWSD instead of HJKL since the leader is , and is on the right side
of the keyboard AWSD is on the left side of the keyboard. 

It just seemed more comfortable and intuitive to use `,` with AWSD than with HJKL

Please play around with it and let me know if you like it or not. Also let me know if any of the old mappings aren't working.