### PR TITLE
Silence Syntastic warnings for routes.js

### DIFF
--- a/config/plugins/syntastic.vim
+++ b/config/plugins/syntastic.vim
@@ -11,3 +11,4 @@ let g:syntastic_check_on_wq = 1
 
 let g:syntastic_warning_symbol = '⚠️'
 let g:syntastic_error_symbol = '💩'
+let g:syntastic_quiet_messages = {'file:p':  ['\mapp/assets/javascripts/routes.js'] }


### PR DESCRIPTION
Loading the file produced so many warnings in the sidebar that it froze
vim for between ~a minute and permanently. This bypasses warnings for
files matching the pattern "app/assets/javascripts/routes.js", but
leaves checking enabled for all other files.