### PR TITLE
Better <leader>C & <leader>cp

### DIFF
--- a/config/mappings.vim
+++ b/config/mappings.vim
@@ -107,8 +107,8 @@ map <leader>/   <plug>NERDCommenterToggle
 cmap <C-A> <C-B>
 
 " Copy current file path to system pasteboard
-map <leader>cp :let @* = expand("%")<CR>:echo "Copied: ".expand("%")<CR>
-map <leader>C :let @* = expand("%").":".line(".")<CR>:echo "Copied: ".expand("%").":".line(".")<CR>
+map <leader>cp :let @* = fnamemodify(expand("%"), ":.")<CR>:echo "Copied: ".fnamemodify(expand("%"), ":.")<CR>
+map <leader>C :let @* = fnamemodify(expand("%"), ":.").":".line(".")<CR>:echo "Copied: ".fnamemodify(expand("%"), ":.").":".line(".")<CR>
 map <silent> <D-C> :let @* = expand("%")<CR>:echo "Copied: ".expand("%")<CR>
 
 " Run tests


### PR DESCRIPTION
Depending on how we open a file in Vim, expand("%") will sometimes give us the full path to the file when generally all we want is the path relative to the project. Wrap expand() in fnamemodify() to always try to use shorter, relative path of file.

[Documentation for fnamemodify()](http://vimdoc.sourceforge.net/htmldoc/eval.html#fnamemodify())